### PR TITLE
修复时间测量的问题；修复不能打开含#目录的问题

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -332,9 +332,14 @@ void MainWindow::cleanRecent_action()
     updateRecentContest(true);
 }
 
+void MainWindow::openFile(QString dir){
+    dir.replace("#","%23");
+    QDesktopServices::openUrl(QUrl("file:///"+dir));
+}
+
 void MainWindow::editFile_action()
 {
-    QDesktopServices::openUrl(QUrl("file:///"+dir_action+file_action));
+    openFile(dir_action+file_action);
 }
 
 void MainWindow::createFile_action()
@@ -348,19 +353,19 @@ void MainWindow::createFile_action()
         QFile file(dir_action+s);
         file.open(QIODevice::WriteOnly);
         file.close();
-        QDesktopServices::openUrl(QUrl("file:///"+dir_action+s));
+        openFile(dir_action+s);
     }
 }
 
 void MainWindow::openDir_action()
 {
-    QDesktopServices::openUrl(QUrl("file:///"+dir_action));
+    openFile(dir_action);
 }
 
 void MainWindow::createDir_action()
 {
     QDir().mkpath(dir_action);
-    QDesktopServices::openUrl(QUrl("file:///"+dir_action));
+    openFile(dir_action);
 }
 
 void MainWindow::removeDir_action()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -37,6 +37,7 @@ private slots:
 
     void removeRecent_action();
     void cleanRecent_action();
+    void openFile(QString dir);
     void editFile_action();
     void createFile_action();
     void openDir_action();

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -262,7 +262,7 @@ void Problem::configureNew(const QString &typ, double timeLim, double memLim, co
         Info x(timeLim,memLim);
         x.in=list[i].first;
         x.out=list[i].second;
-        if (type==ProblemType::AnswersOnly) x.sub=QString("%1%2.out").arg(name).arg(i+1);
+        if (type==ProblemType::AnswersOnly) x.sub=/*QString("%1%2.out").arg(name).arg(i+1)*/x.out;
         sub.point.push_back(que.size());
         que.push_back(x);
         tasks.push_back(sub);


### PR DESCRIPTION
1. 修复了测评某些题目时时限开小TLE而开大后可以通过原时限的问题；
3. 修复了试题文件夹名中含有'#'时不能打开文件目录的问题；