### PR TITLE
fixed2: Cannot open directories or files when path contains special c…

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -334,7 +334,7 @@ void MainWindow::cleanRecent_action()
 
 void MainWindow::editFile_action()
 {
-    QDesktopServices::openUrl(QUrl("file:///"+dir_action+file_action));
+    QDesktopServices::openUrl(QUrl::fromLocalFile(dir_action+file_action));
 }
 
 void MainWindow::createFile_action()
@@ -348,19 +348,19 @@ void MainWindow::createFile_action()
         QFile file(dir_action+s);
         file.open(QIODevice::WriteOnly);
         file.close();
-        QDesktopServices::openUrl(QUrl("file:///"+dir_action+s));
+        QDesktopServices::openUrl(QUrl::fromLocalFile(dir_action+s));
     }
 }
 
 void MainWindow::openDir_action()
 {
-    QDesktopServices::openUrl(QUrl("file:///"+dir_action));
+    QDesktopServices::openUrl(QUrl::fromLocalFile(dir_action));
 }
 
 void MainWindow::createDir_action()
 {
     QDir().mkpath(dir_action);
-    QDesktopServices::openUrl(QUrl("file:///"+dir_action));
+    QDesktopServices::openUrl(QUrl::fromLocalFile(dir_action));
 }
 
 void MainWindow::removeDir_action()


### PR DESCRIPTION
重新解决：修复了试题文件夹名中含有特殊字符时不能打开文件目录的问题；