### PR TITLE
Use QCoreApplication::applicationDirPath() instead of QDir::currentPath()

### DIFF
--- a/src/configure/configuretable.cpp
+++ b/src/configure/configuretable.cpp
@@ -59,7 +59,7 @@ QWidget* ConfigureTableItemDelegate::createEditor(QWidget* parent, const QStyleO
                 model->appendRow(item);
             }
 
-            QStringList dirs = { QDir().currentPath() + "/checker",
+            QStringList dirs = { QCoreApplication::applicationDirPath() + "/checker",
                                  Global::g_contest.data_path + problem_list[index.column()]
                                };
             for (auto dir : dirs)

--- a/src/configure/general/generaltabwidget.cpp
+++ b/src/configure/general/generaltabwidget.cpp
@@ -64,7 +64,7 @@ void GeneralTabWidget::ShowProblemConfiguration(Problem* problem)
     ui->comboBox_custom->clear();
     ui->comboBox_builtin->setCurrentIndex(0);
     QStandardItemModel* model = new QStandardItemModel(ui->comboBox_custom);
-    QStringList dirs = { QDir().currentPath() + "/checker",
+    QStringList dirs = { QCoreApplication::applicationDirPath() + "/checker",
                          Global::g_contest.data_path + problem->Name(),
                        };
     for (auto dir : dirs)

--- a/src/judge/judger/basejudger.cpp
+++ b/src/judge/judger/basejudger.cpp
@@ -126,8 +126,8 @@ TestCaseResult BaseJudger::checkOutput(const QString& inFile, const QString& ans
     QProcess process;
     process.setWorkingDirectory(working_dir);
     QString checkerDir;
-    if (QFile(QDir().currentPath() + "/checker/" + problem->Checker()).exists())
-        checkerDir = QDir().currentPath() + "/checker/";
+    if (QFile(QCoreApplication::applicationDirPath() + "/checker/" + problem->Checker()).exists())
+        checkerDir = QCoreApplication::applicationDirPath() + "/checker/";
     else
         checkerDir = data_dir;
 #ifdef Q_OS_LINUX
@@ -301,11 +301,11 @@ TestCaseResult BaseJudger::runProgram(const QString& exe, double timeLim, double
 
 TestCaseResult BaseJudger::runProgram(const QString& exe, double timeLim, double memLim) const
 {
-    QProcess::execute(QString("chmod +wx \"%1\"").arg(QDir().currentPath() + "/monitor"));
+    QProcess::execute(QString("chmod +wx \"%1\"").arg(QCoreApplication::applicationDirPath() + "/monitor"));
 
     QProcess process;
     process.setWorkingDirectory(working_dir);
-    process.start(QDir().currentPath() + "/monitor", QStringList({ exe,
+    process.start(QCoreApplication::applicationDirPath() + "/monitor", QStringList({ exe,
                                                                    QString::number(timeLim),
                                                                    QString::number(memLim)
                                                                  }));


### PR DESCRIPTION
Use QCoreApplication::applicationDirPath() instead of QDir::currentPath() to get the directory that contains the application executable.