### PR TITLE
Little change of UI

### DIFF
--- a/src/mainwindow/boardtable.cpp
+++ b/src/mainwindow/boardtable.cpp
@@ -1,5 +1,6 @@
 #include <QScrollBar>
 #include <QHeaderView>
+#include <QAbstractButton>
 
 #include "common/global.h"
 #include "common/contest.h"
@@ -69,6 +70,9 @@ BoardTable::BoardTable(QWidget* parent) : QTableWidget(parent),
 
     connect(this->horizontalHeader(), &QHeaderView::sectionMoved, this, &BoardTable::onSectionMove);
     connect(this->horizontalHeader(), &QHeaderView::sectionClicked, this, &BoardTable::onSortTable);
+
+    QAbstractButton* button = this->findChild<QAbstractButton*>();
+    if (button) button->setToolTip("全选");
 }
 
 void BoardTable::ClearBoard()

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -33,8 +33,10 @@ MainWindow::MainWindow(QWidget* parent) :
 
     close_button->setIcon(style()->standardPixmap(QStyle::SP_TitleBarCloseButton));
     close_button->setToolTip("关闭当前竞赛");
-    close_button->setStyleSheet("background-color:transparent");
+    close_button->setFixedSize(ui->menuBar->sizeHint().height(), ui->menuBar->sizeHint().height());
+    close_button->setStyleSheet("QToolButton{border:none;}");
     close_button->setFocusPolicy(Qt::NoFocus);
+    close_button->setCursor(Qt::PointingHandCursor);
     close_button->hide();
     ui->menuBar->setCornerWidget(close_button);
 

--- a/src/mainwindow/mainwindow.ui
+++ b/src/mainwindow/mainwindow.ui
@@ -158,13 +158,8 @@ QMainWindow
    </layout>
   </widget>
   <widget class="QMenuBar" name="menuBar">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>900</width>
-     <height>21</height>
-    </rect>
+   <property name="nativeMenuBar">
+    <bool>false</bool>
    </property>
    <widget class="QMenu" name="menuContest">
     <property name="title">


### PR DESCRIPTION
1. Let the menubar remains in the window on Ubuntu Unity, fix shortcuts do not work.
2. Fix the appearance problem of the menubar corner widget on Ubuntu.
3. Set the tool tip "全选" of the BorderTable corner button.